### PR TITLE
Include untracked files when building config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withkoji/vcc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A library that exposes VCC and ENV values for easy consumption in a Koji app",
   "main": "dist/index.js",
   "scripts": {

--- a/src/tools/readDirectory.js
+++ b/src/tools/readDirectory.js
@@ -4,7 +4,7 @@ import path from 'path';
 
 const readDirectoryRelative = (directory) => {
   try {
-    let list = execSync('git ls-files', { cwd: directory }).toString()
+    let list = execSync('git ls-files && git ls-files --exclude-standard --others', { cwd: directory }).toString()
       .replace(/\n$/, '')
       .split('\n');
 


### PR DESCRIPTION
Fix an issue where adding a new VCC file to the .koji directory would not be available in config object until it is tracked by git