### PR TITLE
Fix configValue always being overwritten by fileValue

### DIFF
--- a/src/tools/writeConfig.js
+++ b/src/tools/writeConfig.js
@@ -19,9 +19,10 @@ const writeConfig = () => {
             configValue = (Array.isArray(configValue) && Array.isArray(fileValue))
               ? configValue.concat(fileValue)
               : Object.assign(configValue, fileValue);
+          } else {
+            // Otherwise, set it
+            configValue = fileValue;
           }
-          // Otherwise, set it
-          configValue = fileValue;
 
           // Finally, set the config key's value
           config[key] = configValue;


### PR DESCRIPTION
Add `else { ... }` around `configValue = fileValue` at lines 22 - 25