### PR TITLE
Resolve no default Config export

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ console.log(Koji.config.settings.name); // Hello World!
 
 Hovering over the `name` property will display a tooltip showing **Type: string, Value: Hello World!**. This allows developers to reference what content will be displayed without having to switch back to the associated VCC file. Additionally, any strings that reference a web address (such as images, sounds, etc) can be clicked on to see the asset in a new browser tab.
 
+#### Building TypeScript Projects with VCC
+
+In order for your TypeScript projects to properly publish with Koji, you will need to add the following line to your `scripts` section of your project's `package.json`:
+
+```
+"prebuild": "koji-vcc preinstall-ts"
+```
+
+This causes your app to build the VCC config files prior to compiling your TypeScript code when publishing, just like when koji-vcc sets a watch on your config files during development. This is necessary to prevent errors by TypeScript during compile time.
+
 ### ENV Mapping
 
 In order to make some `ENV` variables accessible to the frontend (browser), this package also supports some basic mapping so you can do things like `fetch` information from a backend service.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withkoji/vcc",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A library that exposes VCC and ENV values for easy consumption in a Koji app",
   "main": "dist/index.js",
   "files": [

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for koji-vcc 1.1.2
+// Type definitions for koji-vcc 1.1.4
 // Project: https://github.com/madewithkoji/koji-vcc
 // Definitions by: Jeff Peterson <https://github.com/bdjeffyp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
-import Config from './res/config.json';
+import { Config } from './res/config.json';
 
 declare module "@withkoji/vcc" {
   class Handle {


### PR DESCRIPTION
Obviously people aren't making use of TypeScript in Koji since I haven't heard of anyone else having this issue, but TypeScript reports an error when attempting to compile due to the Config import not having a default export. This PR fixes that issue. I have validated the fix in the Koji editor.